### PR TITLE
Modules list command

### DIFF
--- a/commands/add-module.js
+++ b/commands/add-module.js
@@ -42,7 +42,6 @@ module.exports = function addModule (vfs, baseConfig, moduleName, moduleArgs) {
     addedPultModules: addedModules.concat([moduleName])
   })
 
-
   if ( moduleConfig.dependencies || moduleConfig.devDependencies ) {
     // package-merge wants strings :(
     Object.assign(newPackage, {

--- a/commands/add-module.js
+++ b/commands/add-module.js
@@ -1,4 +1,3 @@
-var fs   = require('fs')
 var Path = require('path')
 var semver = require('semver')
 var semverIntersect = require('semver-set').intersect
@@ -19,19 +18,30 @@ module.exports = function addModule (vfs, baseConfig, moduleName, moduleArgs) {
     throw new errors.ModuleError(`Module ${colors.subject(moduleName)} is already a part of this project.`)
   }
 
-  try {
-    fs.accessSync($(`modules/${moduleName}`))
-  }
-  catch (e) {
-    throw new Error(`pult: Module '${moduleName}' does not exist.`)
+  var config = require(`../modules/${moduleName}/config`);
+
+  if ( moduleArgs.length > config.maxCLIArgs ) {
+    throw new errors.TooManyArguments(moduleName, config.maxCLIArgs)
   }
 
-  var config = require(`../modules/${moduleName}/config`)
-  var moduleConfig = config(vfs, baseConfig, moduleArgs)
+  for (var conflict of config.pultModuleConflicts) {
+    if ( baseConfig.package.addedPultModules.includes(conflict) ) {
+      throw new errors.IncompatibleModule(moduleName, conflict)
+    }
+  }
+
+  for (var dep of config.pultModuleDeps) {
+    if ( ! baseConfig.package.addedPultModules.includes(dep) ) {
+      throw new errors.MissingDependency(dep)
+    }
+  }
+
+  var moduleConfig = config.get(vfs, baseConfig, moduleArgs)
 
   var newPackage = Object.assign({}, baseConfig.package, moduleConfig.package || {}, {
     addedPultModules: addedModules.concat([moduleName])
   })
+
 
   if ( moduleConfig.dependencies || moduleConfig.devDependencies ) {
     // package-merge wants strings :(

--- a/commands/list-modules.js
+++ b/commands/list-modules.js
@@ -70,20 +70,19 @@ module.exports = function getListContent(modules) {
   function print(children, indent = '      ', text = '') {
     if ( children.length === 0 ) return ''
     for (var child of children) {
-      text = text
-        .concat(indent)
-        .concat(child.color(child.name))
-        .concat('\n')
-        .concat(print(child.children, `${indent}  `, ''))
+      text += indent
+        + child.color(child.name)
+        + '\n'
+        + print(child.children, `${indent}  `, '')
     }
     return text
   }
 
   return `
-    List of all modules:
+    List of all pult modules:
 ${print(reconcile(depTree))}
 
-    To add a module:
+    To add a pult module:
       $ pult add <module>
 `;
 }

--- a/commands/list-modules.js
+++ b/commands/list-modules.js
@@ -1,0 +1,89 @@
+var Path = require('path')
+var semver = require('semver')
+var semverIntersect = require('semver-set').intersect
+
+var colors = require('../lib/colors')
+var errors = require('../lib/errors')
+
+module.exports = function getListContent(modules) {
+
+  var package = require( Path.resolve( process.cwd(), 'package.json' ) )
+  package.addedPultModules = package.addedPultModules || [];
+  var destValMap = {}
+
+  var depTree = modules.map((moduleName) => {
+    // Retrieve this file's config.
+    var config = require( Path.resolve( __dirname, `../modules/${moduleName}/config` ) );
+
+    // Set color for items that are still possible to use
+    var textColor = colors.fileMod
+
+    // Set color for items that are already in use
+    if ( package.addedPultModules.includes(moduleName) ) {
+      textColor = colors.fileAdd
+    }
+
+    // Set color for items that can't be used due to a conflict
+    if ( config.pultModuleConflicts.some( con => package.addedPultModules.includes(con) ) ) {
+      textColor = colors.error
+    }
+
+    // Set color for items that can't be used because there is a missing dependency
+    if ( ! config.pultModuleDeps.every( dep => package.addedPultModules.includes(dep) ) ) {
+      textColor = colors.error
+    }
+
+    // Build basic node
+    var node = {
+      name: moduleName,
+      children: [],
+      color: textColor
+    }
+
+    // If the node isn't top level, associate it with parent name in object.
+    for (var dep of config.pultModuleDeps) {
+      destValMap[dep] = destValMap[dep] || []
+      destValMap[dep].push(node)
+      return null
+    }
+
+    // Otherwise add it to top level
+    return node
+  })
+
+  // Recursively insert dependencies into the parent's children.
+  function reconcile(children) {
+    if ( children.length === 0  || Object.keys(destValMap).length === 0 ) return children;
+    return children
+      .filter(node => Boolean(node))
+      .map(node => {
+        if ( destValMap[node.name] ) {
+          node.children = node.children.concat(destValMap[node.name])
+          delete destValMap[node.name]
+        }
+        node.children = reconcile(node.children)
+        return node;
+      })
+  }
+
+  // Recursively print out colored and indented text for each module
+  function print(children, indent = '      ', text = '') {
+    if ( children.length === 0 ) return ''
+    for (var child of children) {
+      text = text
+        .concat(indent)
+        .concat(child.color(child.name))
+        .concat('\n')
+        .concat(print(child.children, `${indent}  `, ''))
+    }
+    return text
+  }
+
+  return `
+    List of all modules:
+${print(reconcile(depTree))}
+
+    To add a module:
+      $ pult add <module>
+`;
+}

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var errors = require('./lib/errors')
 var exec = require('./lib/exec')
 var colors = require('./lib/colors')
 
+var fs   = require('fs')
 var Path = require('path')
 var program = require('commander')
 
@@ -33,6 +34,13 @@ program
     module = module.toLowerCase()
     // Wrap everything in co to easily catch errors
     co(function * () {
+
+      try {
+        fs.accessSync( Path.resolve(process.cwd(), `..`, `modules/${module}/config.js` ) )
+      }
+      catch (e) {
+        throw new errors.NonexistentModule(module)
+      }
 
       var config = {
         package: require( Path.resolve(process.cwd(), 'package.json')),

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ program
     co(function * () {
 
       try {
-        fs.accessSync( Path.resolve(process.cwd(), `..`, `modules/${module}/config.js` ) )
+        fs.accessSync( Path.resolve(__dirname,`modules/${module}/config.js` ) )
       }
       catch (e) {
         throw new errors.NonexistentModule(module)
@@ -82,6 +82,18 @@ program
       console.log(`Added ${module}! :)`)
     })
       .then(exit(0), exit(1))
+  })
+
+//
+// List all modules
+//
+program
+  .command('modules')
+  .alias('ls')
+  .action(function () {
+    var modules = fs.readdirSync( Path.resolve( __dirname, './modules' ) )
+    var list = require('./commands/list-modules.js')(modules)
+    console.log(list)
   })
 
 //

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -7,6 +7,25 @@ exports.ModuleError = class ModuleError extends exports.PultError {}
 exports.MissingDependency = class MissingDependency extends exports.PultError {
   constructor(dep) {
     super(`Missing dependency ${ c.subject(dep) }. Try adding it first:\n\n    $ pult add ${dep}`)
-    this.dependency = dep
+  }
+}
+
+exports.IncompatibleModule = class IncompatibleDependency extends exports.PultError {
+  constructor(dep, conflict) {
+    super(`Module ${ c.subject(dep) } is incompatible with the module ${c.subject(conflict)}`)
+  }
+}
+
+exports.TooManyArguments = class TooManyArguments extends exports.PultError {
+  constructor(name, max) {
+    // 0 argumentS, 1 argument, 2 argumentS (English is the worst)
+    const argumentPlurality = max === 1 ? '' : 's';
+    super(`Module ${ c.subject(name) } only allows ${ c.error(max) } argument${argumentPlurality}`)
+  }
+}
+
+exports.NonexistentModule = class NonexistentDependency extends exports.PultError {
+  constructor(name) {
+    super(`Module '${c.subject(name)}' does not exist.`)
   }
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -19,7 +19,7 @@ exports.IncompatibleModule = class IncompatibleDependency extends exports.PultEr
 exports.TooManyArguments = class TooManyArguments extends exports.PultError {
   constructor(name, max) {
     // 0 argumentS, 1 argument, 2 argumentS (English is the worst)
-    const argumentPlurality = max === 1 ? '' : 's';
+    var argumentPlurality = max === 1 ? '' : 's'
     super(`Module ${ c.subject(name) } only allows ${ c.error(max) } argument${argumentPlurality}`)
   }
 }

--- a/modules/api/config.js
+++ b/modules/api/config.js
@@ -1,11 +1,16 @@
 var lib = require('../../lib')
 
 
-module.exports = function configKnex (vfs, baseConfig, moduleArgs) {
+module.exports = {
+  maxCLIArgs: 0,
+  pultModuleDeps: [],
+  pultModuleConflicts: [],
+  get: function get (vfs, baseConfig, moduleArgs) {
 
-  var serverConfig = lib.clone(baseConfig.server)
+    var serverConfig = lib.clone(baseConfig.server)
 
-  serverConfig.routerPipeline.unshift('./mount-api.js')
+    serverConfig.routerPipeline.unshift('./mount-api.js')
 
-  return { server: serverConfig }
+    return { server: serverConfig }
+  }
 }

--- a/modules/cookie-session/config.js
+++ b/modules/cookie-session/config.js
@@ -1,23 +1,25 @@
 var lib = require('../../lib')
 
 
-module.exports = function configCookieSession (vfs, baseConfig, moduleArgs) {
-  if ( moduleArgs.length >= 2 ) {
-    throw new lib.errors.ModuleError('Module `cookie-sessions` only takes 1 argument')
+module.exports = {
+  maxCLIArgs: 0,
+  pultModuleDeps: [],
+  pultModuleConflicts: [],
+  get: function get (vfs, baseConfig, moduleArgs) {
+
+    var serverConfig = lib.clone(baseConfig.server)
+
+    serverConfig.routerPipeline.push('./cookie-sessions.js')
+
+    var config = {
+      dependencies: {
+        "cookie-session": "*",
+      },
+      server: serverConfig,
+    }
+
+    config.installs = Object.keys(config.dependencies)
+
+    return config
   }
-
-  var serverConfig = lib.clone(baseConfig.server)
-
-  serverConfig.routerPipeline.push('./cookie-sessions.js')
-
-  var config = {
-    dependencies: {
-      "cookie-session": "*",
-    },
-    server: serverConfig,
-  }
-
-  config.installs = Object.keys(config.dependencies)
-
-  return config
 }

--- a/modules/knex-model/config.js
+++ b/modules/knex-model/config.js
@@ -1,11 +1,11 @@
 var lib = require('../../lib')
 
 
-module.exports = function configKnex (vfs, baseConfig, moduleArgs) {
-
-  if ( ! baseConfig.package.addedPultModules.includes('knex') ) {
-    throw new lib.errors.MissingDependency('knex')
+module.exports = {
+  maxCLIArgs: 0,
+  pultModuleDeps: [ 'knex' ],
+  pultModuleConflicts: [],
+  get: function get (vfs, baseConfig, moduleArgs) {
+    return {}
   }
-
-  return {}
 }

--- a/modules/knex/config.js
+++ b/modules/knex/config.js
@@ -1,34 +1,35 @@
 var lib = require('../../lib')
 
+module.exports =  {
+  maxCLIArgs: 1,
+  pultModuleDeps: [],
+  pultModuleConflicts: [],
+  get: function get (vfs, baseConfig, moduleArgs) {
 
-module.exports = function configKnex (vfs, baseConfig, moduleArgs) {
-  if ( moduleArgs.length >= 2 ) {
-    throw new lib.errors.ModuleError('Module `knex` only takes 1 argument')
-  }
-
-  var dialect = dialectMap[ moduleArgs[0] ]
-  if ( ! dialect ) {
-    let options = Object.keys(driverMap).sort()
-    throw new lib.errors.ModuleError(`Module ${
-      lib.c.subject('knex')
-    } needs a dialect. Options are:\n\n    ${
-      options.join(', ')
-    }\n\nUpon choosing, re-run the command like this:\n\n    $ pult add knex postgres`)
-  }
-
-  var config = {
-
-    client: driverMap[dialect],
-
-    dependencies: {
-      knex: '^0.12.5',
-      [driverMap[dialect]]: '*',
+    var dialect = dialectMap[ moduleArgs[0] ]
+    if ( ! dialect ) {
+      let options = Object.keys(driverMap).sort()
+      throw new lib.errors.ModuleError(`Module ${
+        lib.c.subject('knex')
+      } needs a dialect. Options are:\n\n    ${
+        options.join(', ')
+      }\n\nUpon choosing, re-run the command like this:\n\n    $ pult add knex postgres`)
     }
+
+    var config = {
+
+      client: driverMap[dialect],
+
+      dependencies: {
+        knex: '^0.12.5',
+        [driverMap[dialect]]: '*',
+      }
+    }
+
+    config.installs = Object.keys(config.dependencies)
+
+    return config
   }
-
-  config.installs = Object.keys(config.dependencies)
-
-  return config
 }
 
 // Taken from https://github.com/tgriesser/knex/tree/3609de76b34cb9ed6171505f3b614c0526c0e9ca/src/dialects

--- a/modules/less/config.js
+++ b/modules/less/config.js
@@ -1,46 +1,48 @@
 var lib = require('../../lib')
 
 
-module.exports = function configClient (vfs, baseConfig, moduleArgs) {
-  if ( moduleArgs.length >= 2 ) {
-    throw new lib.errors.ModuleError('Module `less` only takes 1 argument')
+module.exports = {
+  maxCLIArgs: 0,
+  pultModuleDeps: [],
+  pultModuleConflicts: [],
+  get: function get (vfs, baseConfig, moduleArgs) {
+
+    var serverConfig = lib.clone(baseConfig.server)
+
+    serverConfig.routerPipeline.unshift('./style-bundles.js')
+
+
+    //
+    // Inject link tag into main html file
+    //
+    var isSpa   = baseConfig.package.addedPultModules.includes('spa')
+    var isMarko = baseConfig.package.addedPultModules.includes('marko')
+
+    if ( isSpa || isMarko ) {
+      var htmlPath = baseConfig.projectRoot + (
+        isSpa ? '/client/public/index.html' : '/client/pages/_layouts/main.marko'
+      )
+
+      var html     = vfs.read(htmlPath)
+
+      var spaces = html.match(/( *)<\/head>/)[1]
+      var result = html.replace(
+        '</head>',
+        `  <link rel="stylesheet" type="text/css" href="/app-bundle.css">\n${ spaces }</head>`
+      )
+      vfs.write(htmlPath, result)
+    }
+
+
+    var config = {
+      dependencies: {
+        "node-less-endpoint": "0.x",
+      },
+      server: serverConfig,
+    }
+
+    config.installs = Object.keys(config.dependencies)
+
+    return config
   }
-
-  var serverConfig = lib.clone(baseConfig.server)
-
-  serverConfig.routerPipeline.unshift('./style-bundles.js')
-
-
-  //
-  // Inject link tag into main html file
-  //
-  var isSpa   = baseConfig.package.addedPultModules.includes('spa')
-  var isMarko = baseConfig.package.addedPultModules.includes('marko')
-
-  if ( isSpa || isMarko ) {
-    var htmlPath = baseConfig.projectRoot + (
-      isSpa ? '/client/public/index.html' : '/client/pages/_layouts/main.marko'
-    )
-
-    var html     = vfs.read(htmlPath)
-
-    var spaces = html.match(/( *)<\/head>/)[1]
-    var result = html.replace(
-      '</head>',
-      `  <link rel="stylesheet" type="text/css" href="/app-bundle.css">\n${ spaces }</head>`
-    )
-    vfs.write(htmlPath, result)
-  }
-
-
-  var config = {
-    dependencies: {
-      "node-less-endpoint": "0.x",
-    },
-    server: serverConfig,
-  }
-
-  config.installs = Object.keys(config.dependencies)
-
-  return config
 }

--- a/modules/marko/config.js
+++ b/modules/marko/config.js
@@ -1,47 +1,44 @@
 var lib = require('../../lib')
 
 
-module.exports = function configClient (vfs, baseConfig, moduleArgs) {
-  if ( moduleArgs.length >= 2 ) {
-    throw new lib.errors.ModuleError('Module `marko` only takes 1 argument')
+module.exports = {
+  maxCLIArgs: 0,
+  pultModuleDeps: [],
+  pultModuleConflicts: [ 'spa' ],
+  get: function get (vfs, baseConfig, moduleArgs) {
+
+    var serverConfig = lib.clone(baseConfig.server)
+
+    serverConfig.routerPipeline.unshift('./marko.js')
+
+    var config = {
+      package: {
+        scripts: {
+          start: "./node_modules/.bin/browser-refresh server/index.js"
+        }
+      },
+      dependencies: {
+        "less": "^2.7",
+        "lasso": "^2.8.3",
+        "lasso-marko": "^2.1.0",
+        "lasso-less": "^2.1.0",
+        "marko": "v4.0.0-rc.3",
+        "browser-refresh-taglib": "*",
+      },
+      devDependencies: {
+        "browser-refresh": "^1.7.0",
+      },
+      server: serverConfig,
+    }
+
+    config.installs = Object.keys(config.dependencies)
+
+
+    // git ignore generated files
+    var gitignorePath = baseConfig.projectRoot + '/.gitignore'
+    var gitignore     = vfs.read(gitignorePath)
+    vfs.write(gitignorePath, gitignore + '\n*.marko.js\n.cache/\nclient/public/static/\n')
+
+    return config
   }
-
-  if ( baseConfig.package.addedPultModules.includes('spa') ) {
-    throw new lib.errors.ModuleError('Module `marko` is incompatible with the module `spa`')
-  }
-
-
-  var serverConfig = lib.clone(baseConfig.server)
-
-  serverConfig.routerPipeline.unshift('./marko.js')
-
-  var config = {
-    package: {
-      scripts: {
-        start: "./node_modules/.bin/browser-refresh server/index.js"
-      }
-    },
-    dependencies: {
-      "less": "^2.7",
-      "lasso": "^2.8.3",
-      "lasso-marko": "^2.1.0",
-      "lasso-less": "^2.1.0",
-      "marko": "v4.0.0-rc.3",
-      "browser-refresh-taglib": "*",
-    },
-    devDependencies: {
-      "browser-refresh": "^1.7.0",
-    },
-    server: serverConfig,
-  }
-
-  config.installs = Object.keys(config.dependencies)
-
-
-  // git ignore generated files
-  var gitignorePath = baseConfig.projectRoot + '/.gitignore'
-  var gitignore     = vfs.read(gitignorePath)
-  vfs.write(gitignorePath, gitignore + '\n*.marko.js\n.cache/\nclient/public/static/\n')
-
-  return config
 }

--- a/modules/mithril/config.js
+++ b/modules/mithril/config.js
@@ -4,7 +4,7 @@ var lib = require('../../lib')
 module.exports =  {
   maxCLIArgs: 0,
   pultModuleDeps: [ 'spa' ],
-  pultModuleConflicts: [ 'marko' ],
+  pultModuleConflicts: [ 'marko', 'react' ],
   get: function get (vfs, baseConfig, moduleArgs) {
 
     var serverConfig = lib.clone(baseConfig.server)

--- a/modules/mithril/config.js
+++ b/modules/mithril/config.js
@@ -1,27 +1,25 @@
 var lib = require('../../lib')
 
 
-module.exports = function configClient (vfs, baseConfig, moduleArgs) {
-  if ( ! baseConfig.package.addedPultModules.includes('spa') ) {
-    throw new lib.errors.MissingDependency('spa')
+module.exports =  {
+  maxCLIArgs: 0,
+  pultModuleDeps: [ 'spa' ],
+  pultModuleConflicts: [ 'marko' ],
+  get: function get (vfs, baseConfig, moduleArgs) {
+
+    var serverConfig = lib.clone(baseConfig.server)
+    serverConfig["spa"]["browserify"]["external"].push('mithril')
+
+
+    var config = {
+      dependencies: {
+        "mithril": "^1.0.0",
+      },
+      server: serverConfig,
+    }
+
+    config.installs = Object.keys(config.dependencies)
+
+    return config
   }
-
-  if ( moduleArgs.length >= 2 ) {
-    throw new lib.errors.ModuleError('Module `mithril` only takes 1 argument')
-  }
-
-  var serverConfig = lib.clone(baseConfig.server)
-  serverConfig["spa"]["browserify"]["external"].push('mithril')
-
-
-  var config = {
-    dependencies: {
-      "mithril": "^1.0.0",
-    },
-    server: serverConfig,
-  }
-
-  config.installs = Object.keys(config.dependencies)
-
-  return config
 }

--- a/modules/react/config.js
+++ b/modules/react/config.js
@@ -4,7 +4,7 @@ var lib = require('../../lib')
 module.exports = {
   maxCLIArgs: 0,
   pultModuleDeps: [ 'spa' ],
-  pultModuleConflicts: [ 'marko' ],
+  pultModuleConflicts: [ 'marko', 'mithril' ],
   get: function get (vfs, baseConfig, moduleArgs) {
 
     var serverConfig = lib.clone(baseConfig.server)

--- a/modules/react/config.js
+++ b/modules/react/config.js
@@ -1,34 +1,32 @@
 var lib = require('../../lib')
 
 
-module.exports = function configClient (vfs, baseConfig, moduleArgs) {
-  if ( ! baseConfig.package.addedPultModules.includes('spa') ) {
-    throw new lib.errors.MissingDependency('spa')
+module.exports = {
+  maxCLIArgs: 0,
+  pultModuleDeps: [ 'spa' ],
+  pultModuleConflicts: [ 'marko' ],
+  get: function get (vfs, baseConfig, moduleArgs) {
+
+    var serverConfig = lib.clone(baseConfig.server)
+
+    var browserify = serverConfig["spa"]["browserify"]
+
+    browserify.transform = browserify.transform || []
+    browserify.transform.unshift('reactify')
+
+    browserify.external.push('react', 'react-dom')
+
+    var config = {
+      dependencies: {
+        "react": "*",
+        "react-dom": "*",
+        "reactify": "*",
+      },
+      server: serverConfig,
+    }
+
+    config.installs = Object.keys(config.dependencies)
+
+    return config
   }
-
-  if ( moduleArgs.length >= 2 ) {
-    throw new lib.errors.ModuleError('Module `react` only takes 1 argument')
-  }
-
-  var serverConfig = lib.clone(baseConfig.server)
-
-  var browserify = serverConfig["spa"]["browserify"]
-
-  browserify.transform = browserify.transform || []
-  browserify.transform.unshift('reactify')
-
-  browserify.external.push('react', 'react-dom')
-
-  var config = {
-    dependencies: {
-      "react": "*",
-      "react-dom": "*",
-      "reactify": "*",
-    },
-    server: serverConfig,
-  }
-
-  config.installs = Object.keys(config.dependencies)
-
-  return config
 }

--- a/modules/spa/config.js
+++ b/modules/spa/config.js
@@ -1,34 +1,32 @@
 var lib = require('../../lib')
 
 
-module.exports = function configClient (vfs, baseConfig, moduleArgs) {
-  if ( moduleArgs.length >= 2 ) {
-    throw new lib.errors.ModuleError('Module `spa` only takes 1 argument')
-  }
+module.exports = {
+  maxCLIArgs: 0,
+  pultModuleDeps: [],
+  pultModuleConflicts: [ 'marko' ],
+  get: function get (vfs, baseConfig, moduleArgs) {
 
-  if ( baseConfig.package.addedPultModules.includes('marko') ) {
-    throw new lib.errors.ModuleError('Module `spa` is incompatible with the module `marko`')
-  }
+    var serverConfig = lib.clone(baseConfig.server)
 
-  var serverConfig = lib.clone(baseConfig.server)
-
-  serverConfig["spa"] = {
-    "browserify": {
-      "external": []
+    serverConfig["spa"] = {
+      "browserify": {
+        "external": []
+      }
     }
+
+    serverConfig.routerPipeline.unshift('./client-bundles.js')
+    serverConfig.routerPipeline.push('./catch-all-index-page.js')
+
+    var config = {
+      dependencies: {
+        "browserify-middleware": "^7.1.0",
+      },
+      server: serverConfig,
+    }
+
+    config.installs = Object.keys(config.dependencies)
+
+    return config
   }
-
-  serverConfig.routerPipeline.unshift('./client-bundles.js')
-  serverConfig.routerPipeline.push('./catch-all-index-page.js')
-
-  var config = {
-    dependencies: {
-      "browserify-middleware": "^7.1.0",
-    },
-    server: serverConfig,
-  }
-
-  config.installs = Object.keys(config.dependencies)
-
-  return config
 }


### PR DESCRIPTION
### Changes
* Fix an issue where trying to installing the dependency of a conflicting package displayed the "missing dependency" error instead of the one for incompatible packages. (Can attach screenshot if requested)
* Add more descriptive information to the module configs.
* Add in some custom errors so the output is cleaner
* Implement a new command that lists all of the available modules. 

### Pult Module List
```bash
$ pult ls
$ pult modules
```
Lists out all of the available modules. Modules with dependencies are nested under their parents. Modules that could be installed are shown in yellow. Modules that are installed are shown in green. Modules that are incompatible with other currently installed modules are shown in red.