### PR TITLE
Add catch all command that suggests using --help

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,6 +175,21 @@ program
       .then(exit(0), exit(1))
   })
 
+//
+// Catch-all (invalid arguments)
+//
+program
+  .command('*')
+  .action(function(){
+    exec(`pult --help`)
+  });
+
+//
+// No arguments
+//
+if(process.argv.length === 2) {
+  exec(`pult --help`)
+}
 
 //
 // Utility


### PR DESCRIPTION
Not exactly what you asked for but still a UX improvement IMO. Can explore further to make it so any invalid command runs --help