### PR TITLE
List available modules and generators

### DIFF
--- a/commands/list-generators.js
+++ b/commands/list-generators.js
@@ -1,0 +1,27 @@
+var fs = require('fs')
+var Path = require('path')
+var Promise = require('bluebird')
+var colors = require('../lib/colors')
+
+readDir = Promise.promisify(fs.readdir);
+
+module.exports = function listGenerators (baseConfig, args=[]) {
+  return Promise.all([
+   readDir( Path.resolve( __dirname, '../built-in-generators' ) ).catch(() => []),
+   readDir( `${baseConfig.projectRoot}/generators/` ).catch(() => []) 
+  ])
+  .then(arr => arr[0].concat(arr[1])
+    .filter((gen, idx, collection) => collection.indexOf(gen) === idx) // unique
+    .map(colors.fileMod)
+    .join('\n    ')
+  )
+  .then(generators => `
+  List of all available generators:
+    ${generators}
+
+    Some modules will expose generator(s) upon installation.
+
+    To run a generator:
+      $ pult generate <generator>
+`)
+}

--- a/commands/list-modules.js
+++ b/commands/list-modules.js
@@ -1,12 +1,13 @@
 var Path = require('path')
+var fs = require('fs')
 var semver = require('semver')
 var semverIntersect = require('semver-set').intersect
 
 var colors = require('../lib/colors')
 var errors = require('../lib/errors')
 
-module.exports = function getListContent(modules) {
-
+module.exports = function getListContent() {
+  var modules = fs.readdirSync( Path.resolve( __dirname, '../modules' ) )
   var package = require( Path.resolve( process.cwd(), 'package.json' ) )
   package.addedPultModules = package.addedPultModules || [];
   var destValMap = {}
@@ -67,7 +68,7 @@ module.exports = function getListContent(modules) {
   }
 
   // Recursively print out colored and indented text for each module
-  function print(children, indent = '      ', text = '') {
+  function print(children, indent = '    ', text = '') {
     if ( children.length === 0 ) return ''
     for (var child of children) {
       text += indent
@@ -79,7 +80,7 @@ module.exports = function getListContent(modules) {
   }
 
   return `
-    List of all pult modules:
+  List of all pult modules:
 ${print(reconcile(depTree))}
 
     To add a pult module:


### PR DESCRIPTION
### Changes
- List all available generators when the `generate` command is run with no arguments
- List all modules when the `add` command is run with no arguments
- Updates the `ls` command to list both modules and generators
- Minor formatting tweaks so that logs look natural and match the indentation of `--help` 
- Removes the `modules` alias for the `ls` command. I initially wanted to add a second alias for `generators`, but only one alias is allowed. I removed it for consistency's sake, but let me know if I should add it back in 👍  

I used a quick and dirty `unique` implementation since I think the number of generators will likely be small, but I'm happy to use a more optimal version if requested.

Resolves #2 